### PR TITLE
NOREF Allow CSE Chart to Set Image Pull Secret

### DIFF
--- a/cse/templates/deployment.yaml
+++ b/cse/templates/deployment.yaml
@@ -147,3 +147,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/cse/values.yaml
+++ b/cse/values.yaml
@@ -93,6 +93,8 @@ tolerations: []
 
 affinity: {}
 
+imagePullSecrets: {}
+
 appConfig:
   accountsUrl: "https://api.virtru.com/accounts/api"
   acmUrl: "https://api.virtru.com/acm/api"


### PR DESCRIPTION
### Proposed Changes

This can be useful for customers pulling CSE from their internal registries

See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ for more information

### Checklist

- [ ] I have bumped the necessary versions
- [ ] I have (re-)packaged the updated charts `helm package $CHART_NAME -u`
- [ ] I have updated the repo index `helm repo index .`
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors

### Testing Instructions
