### PR TITLE
feat(gateway): BACK-2190 Add support OAuth2 to Gateway

### DIFF
--- a/gateway/templates/oauth2-secret.yaml
+++ b/gateway/templates/oauth2-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-oauth2-secret
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/component: gateway
+type: Opaque
+stringData:
+  OAUTH2_REFRESH_TOKEN: {{ .Values.appSecrets.oauth2.refreshToken | b64enc | quote }}
+  OAUTH2_CLIENT_ID: {{ .Values.appSecrets.oauth2.clientId | b64enc | quote }}
+  OAUTH2_CLIENT_SECRET: {{ .Values.appSecrets.oauth2.clientSecret | b64enc | quote }}
+  OAUTH2_ACCESS_TOKEN: {{ .Values.appSecrets.oauth2.accessToken | b64enc | quote }}

--- a/gateway/templates/oauth2-token-refresher.yaml
+++ b/gateway/templates/oauth2-token-refresher.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-oauth2-token-refresher
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/component: gateway
+spec:
+  schedule: "*/55 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: oauth2-token-refresher
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              command: ["java", "-jar", "*/smtpproxy.jar", "com/virtru/gateway/smtpproxy/oauth2/TokenRefresher.java"]
+              env:
+                - name: OAUTH2_REFRESH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: oauth2-secret
+                      key: OAUTH2_REFRESH_TOKEN
+                - name: OAUTH2_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: oauth2-secret
+                      key: OAUTH2_CLIENT_ID
+                - name: OAUTH2_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: oauth2-secret
+                      key: OAUTH2_CLIENT_SECRET
+          restartPolicy: OnFailure

--- a/gateway/values.yaml
+++ b/gateway/values.yaml
@@ -55,8 +55,8 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
-# Gateway Modes to enable, 
-# each enabled mode will create a separate 
+# Gateway Modes to enable,
+# each enabled mode will create a separate
 # deployment, service, and configmap
 
 gatewayModes:
@@ -90,8 +90,8 @@ gatewayModes:
     port: 9007
 
 
-# This will create a persistent volume for each 
-# enabled gateway mode. This will keep your postfix queue 
+# This will create a persistent volume for each
+# enabled gateway mode. This will keep your postfix queue
 # intact when pods are destroyed and recreated. You can modify
 # the size of the volume below.
 
@@ -144,7 +144,11 @@ appSecrets:
       <dkim-private-key>
   abac:
     oidcClientSecret: <oidc-client-secret> # The client secret used when authenticating against platform services.
-  
+  oauth2:
+    clientId: <oauth2-client-id>
+    clientSecret: <oauth2-client-secret>
+    refreshToken: <oauth2-refresh-token>
+    accessToken: <oauth2-access-token
 
 additionalConfig:
   saslAuth:
@@ -201,8 +205,8 @@ istioIngress:
   # Use an existing istio gateway
   existingGateway:
   # Name of istio gateway selector
-  gatewaySelectors: 
+  gatewaySelectors:
     istio: ingress
-  ingressHostnames: 
+  ingressHostnames:
     - "*" # Add FQDN, as best practice.
   name: scp


### PR DESCRIPTION
### Proposed Changes

*Add OAuth2 secrets and CronJob for token refresh

### Checklist

- [ ] I have bumped the necessary versions
- [ ] I have (re-)packaged the updated charts `helm package $CHART_NAME -u`
- [ ] I have updated the repo index `helm repo index .`
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors

### Testing Instructions
