### PR TITLE
feat: cks: allow setting ingressClassName

### DIFF
--- a/cks/templates/ingress.yaml
+++ b/cks/templates/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/cks/values.yaml
+++ b/cks/values.yaml
@@ -73,6 +73,7 @@ ingress:
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  ingressClassName: ""
   hosts:
       # -- Change fqdn.yourdomain.com to match the FQDN of your CKS.
     - host: fqdn.yourdomain.com


### PR DESCRIPTION
### Proposed Changes

The annotation `kubernetes.io/ingress.class` is deprecated in favor of ingressClassName on Ingress resources: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

I haven't done any of the checklist items yet. If ya'll are open to this change let me know what else I should do to contribute this change.

### Checklist

- [ ] I have bumped the necessary versions
- [ ] I have (re-)packaged the updated charts `helm package $CHART_NAME -u`
- [ ] I have updated the repo index `helm repo index .`
- [ ] I have added or updated documentation / readme (if appropriate)
- [ ] I have verified that my changes have not introduced new lint errors

### Testing Instructions

Compare the output of the two helm template commands:

```
cd cks
helm template .
helm template . --set ingress.ingressClassName=nginx
```