### PR TITLE
fix: SRE-6728 restore gateway-abac 2.0.2 index entry

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3,7 +3,7 @@ entries:
   cks:
   - apiVersion: v2
     appVersion: v2.2.0
-    created: "2026-06-23T13:01:01.297714-04:00"
+    created: "2026-06-24T10:31:40.691732-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: db41b18f3e513a47da298005230b7cbbdea4033b7de040472fa2dd24ad047471
     name: cks
@@ -13,7 +13,7 @@ entries:
     version: 1.6.0
   - apiVersion: v2
     appVersion: v2.1.0
-    created: "2026-06-23T13:01:01.297143-04:00"
+    created: "2026-06-24T10:31:40.691162-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: 786aa271d1e16a3ad761e66173340426da68e558cb1968c740121cfc51f4621e
     name: cks
@@ -23,7 +23,7 @@ entries:
     version: 1.5.0
   - apiVersion: v2
     appVersion: v2.0.0
-    created: "2026-06-23T13:01:01.296487-04:00"
+    created: "2026-06-24T10:31:40.690631-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: f96d20025b38bd0959cc3c335915fa33315c57b0b83a72ad3ae4cdc458864a90
     name: cks
@@ -33,7 +33,7 @@ entries:
     version: 1.4.0
   - apiVersion: v2
     appVersion: v1.33.0
-    created: "2026-06-23T13:01:01.295217-04:00"
+    created: "2026-06-24T10:31:40.690106-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: 55af235de944bf5e0b83efc0666dee7cf73b1f68dcf66f7c0c1044ace3567b0b
     name: cks
@@ -43,7 +43,7 @@ entries:
     version: 1.3.0
   - apiVersion: v2
     appVersion: v1.32.0
-    created: "2026-06-23T13:01:01.294601-04:00"
+    created: "2026-06-24T10:31:40.689564-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: 3fb60de67855d526375ca96329ef267363651fced78ac1f05953dda426623f37
     name: cks
@@ -53,7 +53,7 @@ entries:
     version: 1.2.6
   - apiVersion: v2
     appVersion: v1.31.0
-    created: "2026-06-23T13:01:01.294161-04:00"
+    created: "2026-06-24T10:31:40.689037-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: b1081a5bdf32e949174e9992d1edb80e18931d0eb0d8c297848cdd95a8217923
     name: cks
@@ -63,7 +63,7 @@ entries:
     version: 1.2.5
   - apiVersion: v2
     appVersion: v1.29.0
-    created: "2026-06-23T13:01:01.293568-04:00"
+    created: "2026-06-24T10:31:40.688095-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: e38ec180fae7689f6ebb55c77581403533f5926c0b217f59ae05a92c71d2b1fa
     name: cks
@@ -73,7 +73,7 @@ entries:
     version: 1.2.4
   - apiVersion: v2
     appVersion: v1.28.0
-    created: "2026-06-23T13:01:01.293064-04:00"
+    created: "2026-06-24T10:31:40.68745-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: 443b1d3b5c40dab08f0516410b72e5e653140cb9ac06e639b7af6609dd14713c
     name: cks
@@ -83,7 +83,7 @@ entries:
     version: 1.2.3
   - apiVersion: v2
     appVersion: v1.27.0
-    created: "2026-06-23T13:01:01.292704-04:00"
+    created: "2026-06-24T10:31:40.686987-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: 71b09cf94407c7067705a08f57b302fca607c7630ae2cff33ee06c2af9faf8f7
     name: cks
@@ -93,7 +93,7 @@ entries:
     version: 1.2.2
   - apiVersion: v2
     appVersion: v1.26.0
-    created: "2026-06-23T13:01:01.292329-04:00"
+    created: "2026-06-24T10:31:40.686475-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: cc7605ad22518a47791c27f9763924710dec6f8f88a02e9a1a62c0e65627f4e6
     name: cks
@@ -103,7 +103,7 @@ entries:
     version: 1.2.1
   - apiVersion: v2
     appVersion: v1.22.0
-    created: "2026-06-23T13:01:01.291961-04:00"
+    created: "2026-06-24T10:31:40.686001-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: 1d5c111597777380ffb0637076bbe476ca4e8798742bddbb136a5459f8055777
     name: cks
@@ -113,7 +113,7 @@ entries:
     version: 1.2.0
   - apiVersion: v2
     appVersion: v1.22.0
-    created: "2026-06-23T13:01:01.291432-04:00"
+    created: "2026-06-24T10:31:40.685596-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: 90c294e79daa798e8146da6aa0790b1815de01bffd31469587391919e33d0be8
     name: cks
@@ -123,7 +123,7 @@ entries:
     version: 1.1.0
   - apiVersion: v2
     appVersion: v1.18.0
-    created: "2026-06-23T13:01:01.290917-04:00"
+    created: "2026-06-24T10:31:40.685116-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: 1e9986ab1c04b32bdce2093304106d27de1e03b34bf812ad1f15533e8d498810
     name: cks
@@ -133,7 +133,7 @@ entries:
     version: 1.0.0
   - apiVersion: v2
     appVersion: v1.16.0
-    created: "2026-06-23T13:01:01.290403-04:00"
+    created: "2026-06-24T10:31:40.684725-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: 2cfa861c1903236112a12aadac665ff721c77096b356aff1df5511af1cdba89d
     name: cks
@@ -143,7 +143,7 @@ entries:
     version: 0.8.8
   - apiVersion: v2
     appVersion: v1.15.0
-    created: "2026-06-23T13:01:01.290081-04:00"
+    created: "2026-06-24T10:31:40.68433-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: bd3eea02a8b07b522957082972d2ae3e51d35c7073cd2da60d9db55d6da7563d
     name: cks
@@ -153,7 +153,7 @@ entries:
     version: 0.8.7
   - apiVersion: v2
     appVersion: v1.13.0
-    created: "2026-06-23T13:01:01.289737-04:00"
+    created: "2026-06-24T10:31:40.683939-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: 7425699c8784e4181f007be7be906380bf7b0078a2df14901c3af7d2a87170ae
     name: cks
@@ -163,7 +163,7 @@ entries:
     version: 0.8.6
   - apiVersion: v2
     appVersion: v1.12.0
-    created: "2026-06-23T13:01:01.288552-04:00"
+    created: "2026-06-24T10:31:40.682156-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: f9628f527bdbda0475f49ecac2b035f4b7c2eaf99c242f0c7772f38cbf4be47b
     name: cks
@@ -173,7 +173,7 @@ entries:
     version: 0.8.5
   - apiVersion: v2
     appVersion: v1.10.0
-    created: "2026-06-23T13:01:01.28806-04:00"
+    created: "2026-06-24T10:31:40.681639-04:00"
     description: A service for Virtru customers who wish to manage their own keys
     digest: 366716a9b69c570ed8a74b418a9e869951634a342ec6925c07311f5fc90b0785
     name: cks
@@ -184,7 +184,7 @@ entries:
   common-lib:
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.297924-04:00"
+    created: "2026-06-24T10:31:40.691918-04:00"
     description: Common helper library
     digest: 66c249a5ad2b9fc12404f69d75638773d500513d628b7a9e0e45798021b77d9f
     name: common-lib
@@ -195,7 +195,7 @@ entries:
   cse:
   - apiVersion: v2
     appVersion: v5.10.0
-    created: "2026-06-23T13:01:01.304121-04:00"
+    created: "2026-06-24T10:31:40.69958-04:00"
     description: A Helm chart for the Virtru Private Keystore for Google Client Side
       Encryption (CSE)
     digest: 69d91da8fb50a475dabde49ecca2529eb7dd55d24cf5ed3e4668df0cb8821609
@@ -206,7 +206,7 @@ entries:
     version: 1.1.4
   - apiVersion: v2
     appVersion: v5.9.4
-    created: "2026-06-23T13:01:01.30357-04:00"
+    created: "2026-06-24T10:31:40.69903-04:00"
     description: A Helm chart for the Virtru Private Keystore for Google Client Side
       Encryption (CSE)
     digest: 201ecaa1ffd5399bcd6849b3b0bbd178f94075f3cd5acbcbf1525a9351bcefda
@@ -217,7 +217,7 @@ entries:
     version: 1.1.3
   - apiVersion: v2
     appVersion: v5.9.3
-    created: "2026-06-23T13:01:01.303152-04:00"
+    created: "2026-06-24T10:31:40.698491-04:00"
     description: A Helm chart for the Virtru Private Keystore for Google Client Side
       Encryption (CSE)
     digest: 032fda9a8ef484acd1e9b328a12c7e37a94a4a4abe4f2a4647439758c11a0996
@@ -228,7 +228,7 @@ entries:
     version: 1.1.2
   - apiVersion: v2
     appVersion: v5.9.2
-    created: "2026-06-23T13:01:01.302715-04:00"
+    created: "2026-06-24T10:31:40.698047-04:00"
     description: A Helm chart for the Virtru Private Keystore for Google Client Side
       Encryption (CSE)
     digest: 44eb099d567286ce127f99184c0c4070da14de209610adf9586088aa9e2d568b
@@ -239,7 +239,7 @@ entries:
     version: 1.1.1
   - apiVersion: v2
     appVersion: v5.9.1
-    created: "2026-06-23T13:01:01.302272-04:00"
+    created: "2026-06-24T10:31:40.697576-04:00"
     description: A Helm chart for the Virtru Private Keystore for Google Client Side
       Encryption (CSE)
     digest: d41a58b27c12029835a778ffe13ea876c6e230e99ea65b30389513daf6877317
@@ -250,7 +250,7 @@ entries:
     version: 1.1.0
   - apiVersion: v2
     appVersion: v5.9.1
-    created: "2026-06-23T13:01:01.301478-04:00"
+    created: "2026-06-24T10:31:40.69709-04:00"
     description: A Helm chart for the Virtru Private Keystore for Google Client Side
       Encryption (CSE)
     digest: f44b040c71ded16a193d7a5b98806d49f978059727701f7a9b5a0aa3be4ec6a5
@@ -261,7 +261,7 @@ entries:
     version: 1.0.0
   - apiVersion: v2
     appVersion: v5.9.1
-    created: "2026-06-23T13:01:01.300918-04:00"
+    created: "2026-06-24T10:31:40.695609-04:00"
     description: A Helm chart for Kubernetes
     digest: a5bad8ee163fde35407d3aed8b1d4c90819293b71574f82e734ba99e624f4c97
     name: cse
@@ -271,7 +271,7 @@ entries:
     version: 0.8.2
   - apiVersion: v2
     appVersion: v5.9.1
-    created: "2026-06-23T13:01:01.300453-04:00"
+    created: "2026-06-24T10:31:40.695058-04:00"
     description: A Helm chart for Kubernetes
     digest: ac668f68f470467b0cf7510b4a49ff366a100c87c950e7054ff94e478d717229
     name: cse
@@ -281,7 +281,7 @@ entries:
     version: 0.8.1
   - apiVersion: v2
     appVersion: v5.8.0
-    created: "2026-06-23T13:01:01.300111-04:00"
+    created: "2026-06-24T10:31:40.694623-04:00"
     description: A Helm chart for Kubernetes
     digest: 3b8dfd52b42b32c54303f3a7c5c024ab85fdb1e2cf2b9b3acd913ee6f3b7bb38
     name: cse
@@ -291,7 +291,7 @@ entries:
     version: 0.8.0
   - apiVersion: v2
     appVersion: v5.7.3
-    created: "2026-06-23T13:01:01.299763-04:00"
+    created: "2026-06-24T10:31:40.693493-04:00"
     description: A Helm chart for Kubernetes
     digest: 3db368ed7efc3f21e7d9f310981a16022f50dbe251f0de27e749741ca7ee405c
     name: cse
@@ -301,7 +301,7 @@ entries:
     version: 0.7.13
   - apiVersion: v2
     appVersion: v5.7.3
-    created: "2026-06-23T13:01:01.299242-04:00"
+    created: "2026-06-24T10:31:40.693106-04:00"
     description: A Helm chart for Kubernetes
     digest: 5ceeae9499d1d10675898a63d98cfecfa5699f6868bf7c76f0215196a6e15596
     name: cse
@@ -311,7 +311,7 @@ entries:
     version: 0.7.12
   - apiVersion: v2
     appVersion: v5.7.3
-    created: "2026-06-23T13:01:01.298759-04:00"
+    created: "2026-06-24T10:31:40.692744-04:00"
     description: A Helm chart for Kubernetes
     digest: cfb101c7db9a19a416e376396e0c68b2767adfb163b044179cc3f520dee8a038
     name: cse
@@ -321,7 +321,7 @@ entries:
     version: 0.7.11
   - apiVersion: v2
     appVersion: v5.7.1
-    created: "2026-06-23T13:01:01.298355-04:00"
+    created: "2026-06-24T10:31:40.69231-04:00"
     description: A Helm chart for Kubernetes
     digest: 6ed78a229dd39fe38948a34aa103af20ed086c53ca09d373c60cc88bcfd9eb4f
     name: cse
@@ -332,7 +332,7 @@ entries:
   gateway:
   - apiVersion: v2
     appVersion: v2.75.0
-    created: "2026-06-23T13:01:01.31245-04:00"
+    created: "2026-06-24T10:31:40.708412-04:00"
     description: A Helm chart for Kubernetes
     digest: 2d2f9fa3a4beec993c8afdf0a46103e60d34cda43b6cd9e89cb743fc2801a851
     name: gateway
@@ -342,7 +342,7 @@ entries:
     version: 2.5.5
   - apiVersion: v2
     appVersion: v2.74.0
-    created: "2026-06-23T13:01:01.311982-04:00"
+    created: "2026-06-24T10:31:40.707898-04:00"
     description: A Helm chart for Kubernetes
     digest: 92b670111d79326e4b4b1ee38a2f3a8f6d1702f6482faf394138c872fa7fb4eb
     name: gateway
@@ -352,7 +352,7 @@ entries:
     version: 2.5.4
   - apiVersion: v2
     appVersion: v2.72.0
-    created: "2026-06-23T13:01:01.311309-04:00"
+    created: "2026-06-24T10:31:40.707379-04:00"
     description: A Helm chart for Kubernetes
     digest: ba0c6971cfecad813e12e59c8116add298d63e262d9d795cca09aa38bb9a7fba
     name: gateway
@@ -362,7 +362,7 @@ entries:
     version: 2.5.3
   - apiVersion: v2
     appVersion: v2.71.0
-    created: "2026-06-23T13:01:01.310726-04:00"
+    created: "2026-06-24T10:31:40.706862-04:00"
     description: A Helm chart for Kubernetes
     digest: cc6d5ea60f61c4a56510a06fc9b8e1e7db9ea2757b4306c0a67059ea6445ea42
     name: gateway
@@ -372,7 +372,7 @@ entries:
     version: 2.5.2
   - apiVersion: v2
     appVersion: v2.69.0
-    created: "2026-06-23T13:01:01.31022-04:00"
+    created: "2026-06-24T10:31:40.706086-04:00"
     description: A Helm chart for Kubernetes
     digest: ac366a79a93d0e9abfcdfcc62bdaf123d4fbffa9394e4855b2738b600ef05c66
     name: gateway
@@ -382,7 +382,7 @@ entries:
     version: 2.5.1
   - apiVersion: v2
     appVersion: v2.63.0
-    created: "2026-06-23T13:01:01.309539-04:00"
+    created: "2026-06-24T10:31:40.705454-04:00"
     description: A Helm chart for Kubernetes
     digest: e2b2471814830f7d30e039af59c347378afc1e43eec64f01f8df31ab42b9c5d6
     name: gateway
@@ -392,7 +392,7 @@ entries:
     version: 2.5.0
   - apiVersion: v2
     appVersion: v2.60.0
-    created: "2026-06-23T13:01:01.308847-04:00"
+    created: "2026-06-24T10:31:40.704784-04:00"
     description: A Helm chart for Kubernetes
     digest: 3d589962a48866e09bf0d529ae78042929ed613d09ad1957df21f90e872ca034
     name: gateway
@@ -402,7 +402,7 @@ entries:
     version: 2.4.0
   - apiVersion: v2
     appVersion: v2.54.0
-    created: "2026-06-23T13:01:01.304746-04:00"
+    created: "2026-06-24T10:31:40.70022-04:00"
     description: A Helm chart for Kubernetes
     digest: 88d907263a2b71bb57615a28587b522fde50b3aeb5afdb641fa2546a3da10936
     name: gateway
@@ -413,7 +413,20 @@ entries:
   gateway-abac:
   - apiVersion: v2
     appVersion: v2.0.5
-    created: "2026-06-23T13:01:01.315413-04:00"
+    created: "2026-06-24T10:31:40.711782-04:00"
+    description: A Helm chart for the Virtru Data Protection Gateway powered by the
+      Virtru Data Security Platform.
+    digest: 2017a5bb437384d5af24955549694a7137816d51bf169c06091920fcbde24413
+    maintainers:
+    - name: Virtru
+    name: gateway-abac
+    type: application
+    urls:
+    - gateway-abac-2.0.2.tgz
+    version: 2.0.2
+  - apiVersion: v2
+    appVersion: v2.0.5
+    created: "2026-06-24T10:31:40.711217-04:00"
     description: A Helm chart for the Virtru Data Protection Gateway powered by the
       Virtru Data Security Platform.
     digest: 89cafdfba6c3810e15e60c7ceb8201c694c9f3e32dd0fc21475fdb11809216e5
@@ -426,7 +439,7 @@ entries:
     version: 2.0.1
   - apiVersion: v2
     appVersion: v2.0.5
-    created: "2026-06-23T13:01:01.314983-04:00"
+    created: "2026-06-24T10:31:40.710609-04:00"
     description: A Helm chart for the Virtru Data Protection Gateway powered by the
       Virtru Data Security Platform.
     digest: 4edfdad15458dc5c23b1d62b6f5b97ab1be3ce4e99198de3c1b145e4f751b795
@@ -439,7 +452,7 @@ entries:
     version: 2.0.0
   - apiVersion: v2
     appVersion: v2.0.5
-    created: "2026-06-23T13:01:01.31453-04:00"
+    created: "2026-06-24T10:31:40.710119-04:00"
     description: A Helm chart for the Virtru Data Protection Gateway powered by the
       Virtru Data Security Platform.
     digest: 3c9d848364587c0723bc1f6e61b7d0e755d9ef74813f0f86418eea6aa23032e5
@@ -452,7 +465,7 @@ entries:
     version: 1.1.1
   - apiVersion: v2
     appVersion: v2.0.5
-    created: "2026-06-23T13:01:01.313932-04:00"
+    created: "2026-06-24T10:31:40.709701-04:00"
     description: A Helm chart for the Virtru Data Protection Gateway powered by the
       Virtru Data Security Platform.
     digest: 29bc76f9dc6cfe9d9727fda8f0e85ffb9713fa5b53bb6388306269aa8b02aab0
@@ -467,7 +480,7 @@ entries:
     version: 1.1.0
   - apiVersion: v2
     appVersion: v2.0.4
-    created: "2026-06-23T13:01:01.313326-04:00"
+    created: "2026-06-24T10:31:40.709305-04:00"
     description: A Helm chart for the Gateway OpenTDF PEP
     digest: c01682f6a76e7c270093f90e82cdb6ad804fdbf86f7d9173f4e438aa581a30c5
     maintainers:
@@ -479,7 +492,7 @@ entries:
     version: 1.0.0
   - apiVersion: v2
     appVersion: v2.0.4
-    created: "2026-06-23T13:01:01.312905-04:00"
+    created: "2026-06-24T10:31:40.70882-04:00"
     description: A Helm chart for the Gateway OpenTDF PEP
     digest: c241fa22e8021636e8a6f593e438d01cf11828093aac3d21053cddddeff3da92
     maintainers:
@@ -492,7 +505,7 @@ entries:
   o365-abac:
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.316299-04:00"
+    created: "2026-06-24T10:31:40.712871-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -506,7 +519,7 @@ entries:
     version: 0.2.0
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.315808-04:00"
+    created: "2026-06-24T10:31:40.712317-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -521,7 +534,7 @@ entries:
   platform:
   - apiVersion: v2
     appVersion: 0.1.6
-    created: "2026-06-23T13:01:01.37634-04:00"
+    created: "2026-06-24T10:31:40.776703-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -593,7 +606,7 @@ entries:
     version: 0.4.1
   - apiVersion: v2
     appVersion: 0.1.5
-    created: "2026-06-23T13:01:01.372461-04:00"
+    created: "2026-06-24T10:31:40.772244-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -665,7 +678,7 @@ entries:
     version: 0.4.0
   - apiVersion: v2
     appVersion: 0.1.4
-    created: "2026-06-23T13:01:01.368622-04:00"
+    created: "2026-06-24T10:31:40.7681-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -737,7 +750,7 @@ entries:
     version: 0.3.9
   - apiVersion: v2
     appVersion: 0.1.4
-    created: "2026-06-23T13:01:01.364881-04:00"
+    created: "2026-06-24T10:31:40.764156-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -809,7 +822,7 @@ entries:
     version: 0.3.7
   - apiVersion: v2
     appVersion: 0.1.4
-    created: "2026-06-23T13:01:01.361-04:00"
+    created: "2026-06-24T10:31:40.760126-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -881,7 +894,7 @@ entries:
     version: 0.3.6
   - apiVersion: v2
     appVersion: 0.1.4
-    created: "2026-06-23T13:01:01.356979-04:00"
+    created: "2026-06-24T10:31:40.75567-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -953,7 +966,7 @@ entries:
     version: 0.3.5
   - apiVersion: v2
     appVersion: 0.1.4
-    created: "2026-06-23T13:01:01.352824-04:00"
+    created: "2026-06-24T10:31:40.751802-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -1025,7 +1038,7 @@ entries:
     version: 0.3.4
   - apiVersion: v2
     appVersion: 0.1.4
-    created: "2026-06-23T13:01:01.348587-04:00"
+    created: "2026-06-24T10:31:40.74777-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -1097,7 +1110,7 @@ entries:
     version: 0.3.3
   - apiVersion: v2
     appVersion: 0.1.3
-    created: "2026-06-23T13:01:01.344537-04:00"
+    created: "2026-06-24T10:31:40.743636-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -1169,7 +1182,7 @@ entries:
     version: 0.3.2
   - apiVersion: v2
     appVersion: 0.1.3
-    created: "2026-06-23T13:01:01.340765-04:00"
+    created: "2026-06-24T10:31:40.739335-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -1241,7 +1254,7 @@ entries:
     version: 0.3.1
   - apiVersion: v2
     appVersion: 0.1.3
-    created: "2026-06-23T13:01:01.33662-04:00"
+    created: "2026-06-24T10:31:40.734734-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -1313,7 +1326,7 @@ entries:
     version: 0.3.0
   - apiVersion: v2
     appVersion: 0.1.3
-    created: "2026-06-23T13:01:01.3325-04:00"
+    created: "2026-06-24T10:31:40.730551-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -1378,7 +1391,7 @@ entries:
     version: 0.2.2
   - apiVersion: v2
     appVersion: 0.1.3
-    created: "2026-06-23T13:01:01.328412-04:00"
+    created: "2026-06-24T10:31:40.72616-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -1443,7 +1456,7 @@ entries:
     version: 0.2.1
   - apiVersion: v2
     appVersion: 0.1.3
-    created: "2026-06-23T13:01:01.324476-04:00"
+    created: "2026-06-24T10:31:40.722074-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -1508,7 +1521,7 @@ entries:
     version: 0.2.0
   - apiVersion: v2
     appVersion: 0.1.3
-    created: "2026-06-23T13:01:01.320251-04:00"
+    created: "2026-06-24T10:31:40.717962-04:00"
     dependencies:
     - condition: abacus.enabled
       name: abacus
@@ -1574,7 +1587,7 @@ entries:
   platform-embedded-keycloak:
   - apiVersion: v2
     appVersion: 0.1.2
-    created: "2026-06-23T13:01:01.384047-04:00"
+    created: "2026-06-24T10:31:40.784485-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1592,7 +1605,7 @@ entries:
     version: 0.1.9
   - apiVersion: v2
     appVersion: 0.1.1
-    created: "2026-06-23T13:01:01.382798-04:00"
+    created: "2026-06-24T10:31:40.783279-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1610,7 +1623,7 @@ entries:
     version: 0.1.8
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.381279-04:00"
+    created: "2026-06-24T10:31:40.782174-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1628,7 +1641,7 @@ entries:
     version: 0.1.7
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.380243-04:00"
+    created: "2026-06-24T10:31:40.780344-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1646,7 +1659,7 @@ entries:
     version: 0.1.6
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.379043-04:00"
+    created: "2026-06-24T10:31:40.779286-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1664,7 +1677,7 @@ entries:
     version: 0.1.5
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.377899-04:00"
+    created: "2026-06-24T10:31:40.778032-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1683,7 +1696,7 @@ entries:
   platform-embedded-postgresql:
   - apiVersion: v2
     appVersion: 0.3.0
-    created: "2026-06-23T13:01:01.388473-04:00"
+    created: "2026-06-24T10:31:40.789377-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1701,7 +1714,7 @@ entries:
     version: 0.3.0
   - apiVersion: v2
     appVersion: 0.2.0
-    created: "2026-06-23T13:01:01.386117-04:00"
+    created: "2026-06-24T10:31:40.787066-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1720,7 +1733,7 @@ entries:
   platform-keycloak-bootstrapper:
   - apiVersion: v2
     appVersion: 0.1.2
-    created: "2026-06-23T13:01:01.391332-04:00"
+    created: "2026-06-24T10:31:40.792935-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1740,7 +1753,7 @@ entries:
     version: 0.1.9
   - apiVersion: v2
     appVersion: 0.1.1
-    created: "2026-06-23T13:01:01.39074-04:00"
+    created: "2026-06-24T10:31:40.79228-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1760,7 +1773,7 @@ entries:
     version: 0.1.8
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.390288-04:00"
+    created: "2026-06-24T10:31:40.791765-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1780,7 +1793,7 @@ entries:
     version: 0.1.7
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.389967-04:00"
+    created: "2026-06-24T10:31:40.790951-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1800,7 +1813,7 @@ entries:
     version: 0.1.6
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.389433-04:00"
+    created: "2026-06-24T10:31:40.79038-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1820,7 +1833,7 @@ entries:
     version: 0.1.5
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.388942-04:00"
+    created: "2026-06-24T10:31:40.789874-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1841,7 +1854,7 @@ entries:
   sharepoint:
   - apiVersion: v2
     appVersion: 0.6.0
-    created: "2026-06-23T13:01:01.393841-04:00"
+    created: "2026-06-24T10:31:40.796122-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1855,7 +1868,7 @@ entries:
     version: 0.6.0
   - apiVersion: v2
     appVersion: 0.5.0
-    created: "2026-06-23T13:01:01.3935-04:00"
+    created: "2026-06-24T10:31:40.795612-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1869,7 +1882,7 @@ entries:
     version: 0.5.0
   - apiVersion: v2
     appVersion: 0.4.0
-    created: "2026-06-23T13:01:01.393155-04:00"
+    created: "2026-06-24T10:31:40.79517-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1883,7 +1896,7 @@ entries:
     version: 0.4.0
   - apiVersion: v2
     appVersion: 0.3.0
-    created: "2026-06-23T13:01:01.39278-04:00"
+    created: "2026-06-24T10:31:40.794751-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1897,7 +1910,7 @@ entries:
     version: 0.3.0
   - apiVersion: v2
     appVersion: 0.2.0
-    created: "2026-06-23T13:01:01.392326-04:00"
+    created: "2026-06-24T10:31:40.793955-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1911,7 +1924,7 @@ entries:
     version: 0.2.0
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2026-06-23T13:01:01.391805-04:00"
+    created: "2026-06-24T10:31:40.793445-04:00"
     dependencies:
     - name: common-lib
       repository: file://../common-lib
@@ -1923,4 +1936,4 @@ entries:
     urls:
     - sharepoint-0.1.0.tgz
     version: 0.1.0
-generated: "2026-06-23T13:01:01.286952-04:00"
+generated: "2026-06-24T10:31:40.680614-04:00"


### PR DESCRIPTION
## Summary
- regenerate Helm repository index.yaml
- restore gateway-abac 2.0.2 to the chart repo index

## Validation
- verified gateway-abac-2.0.2.tgz reports chart version 2.0.2
- served this worktree as a temporary chart repo and confirmed a fresh Helm cache sees local-virtru/gateway-abac 2.0.2