### PR TITLE
docs(cks): clarify keyId is Virtru-provisioned UUID, not caller-supplied (DSPX-4161)

### DIFF
--- a/cks/values.yaml
+++ b/cks/values.yaml
@@ -165,7 +165,7 @@ appConfig:
   kasMetadataDir: /app/data
 
   # -- Key Management Configuration
-  # -- Unique identifier for the active key pair. Must match the key_id registered with Virtru.
+  # -- The KAS Key ID provisioned by Virtru during DSP org provisioning (a UUID). Use the Virtru-provided value exactly; it cannot be chosen or supplied.
   keyId: ""
   kasPublicKeyFile: /app/keys/rsa001.pub
   kasPrivateKeyFile: /app/keys/rsa001.pem


### PR DESCRIPTION
## What

Rewords the `appConfig.keyId` comment in `cks/values.yaml` to reflect [DSPX-4161](https://virtru.atlassian.net/browse/DSPX-4161).

**Before:**
```yaml
# -- Unique identifier for the active key pair. Must match the key_id registered with Virtru.
keyId: ""
```
**After:**
```yaml
# -- The KAS Key ID provisioned by Virtru during DSP org provisioning (a UUID). Use the Virtru-provided value exactly; it cannot be chosen or supplied.
keyId: ""
```

## Why

DSPX-4161 removes the ability for callers to supply a KID during SaaS DSP org provisioning — the provisioning service now generates it automatically as a UUID. The old comment ("registered with Virtru") could read as if the operator chooses/registers the value. This clarifies it is Virtru-provided and used as-is. Wording avoids internal tool names since `values.yaml` is customer-facing.

## Scope / notes

- **Comment-only change. No behavior change** — the empty-string default and the `configmap.yaml` mapping (`KEY_ID: {{ default "rsa1" .Values.appConfig.keyId }}`) are untouched.
- Not addressed here (flagging for the DSP team): if `KEY_ID` is the DSP KAS Key ID (now always a UUID), the configmap's `"rsa1"` fallback default may be worth revisiting — left as-is pending confirmation.
- The chart `README.md` Values table is stale/pre-KAS (missing the KAS `appConfig` keys); a `helm-docs` regen is a separate follow-up, not included here.

## Tracking

Part of the CKS/KAS + customer-facing docs alignment for DSPX-4161. Rollout tracked under **CD-3854** (CKS/KAS → DSP Filesystem Mode: SA Readiness & Customer Rollout Tracking).

[DSPX-4161]: https://virtru.atlassian.net/browse/DSPX-4161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ